### PR TITLE
Pass request timeout to cached session.

### DIFF
--- a/okta_jwt_verifier/request_executor.py
+++ b/okta_jwt_verifier/request_executor.py
@@ -38,7 +38,8 @@ class RequestExecutor:
 
         Return response in json-format.
         """
-        request_params = {'headers': params.get('headers')}
+        request_params = {'headers': params.get('headers'),
+                          'timeout': self.request_timeout}
         if self.proxy:
             request_params['proxy'] = self.proxy
 

--- a/tests/unit/test_request_executor.py
+++ b/tests/unit/test_request_executor.py
@@ -1,5 +1,6 @@
 import pytest
 from okta_jwt_verifier import JWTVerifier, __version__ as version
+from okta_jwt_verifier.constants import REQUEST_TIMEOUT
 
 
 @pytest.mark.asyncio
@@ -18,7 +19,8 @@ async def test_proxy(mocker):
     mock_fire_request.assert_called_with(mock_fire_request,
                                          f'{issuer}/oauth2/v1/keys',
                                          headers={'User-Agent': f'okta-jwt-verifier-python/{version}',
-                                                  'Content-Type': 'application/json'})
+                                                  'Content-Type': 'application/json'},
+                                         timeout=REQUEST_TIMEOUT)
 
     jwt_verifier = JWTVerifier(issuer, proxy='http://test_proxy.com')
     jwt_verifier.request_executor.fire_request = mock_fire_request
@@ -28,4 +30,5 @@ async def test_proxy(mocker):
                                          f'{issuer}/oauth2/v1/keys',
                                          headers={'User-Agent': f'okta-jwt-verifier-python/{version}',
                                                   'Content-Type': 'application/json'},
+                                         timeout=REQUEST_TIMEOUT,
                                          proxy='http://test_proxy.com')


### PR DESCRIPTION
Related to https://github.com/okta/okta-jwt-verifier-python/issues/22