### PR TITLE
Add CI checks for python 3.9 and 3.10, update setup.py

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ jobs:
       name: "Flake8 Check"
       script:
         - echo "Code Style check..."
-        - "flake8 --extend-ignore=E501 okta/"
+        - "flake8 --extend-ignore=E501 okta_jwt_verifier/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
+  - "3.10"
 
 install:
   - pip install -U -r requirements.txt
   - pip install -U -r test_requirements.txt
+  - pip install flake8
 
 script:
   - echo "Running tests in job stages..."
@@ -28,4 +31,4 @@ jobs:
       name: "Flake8 Check"
       script:
         - echo "Code Style check..."
-        - "flake8 okta_jwt_verifier/"
+        - "flake8 --extend-ignore=E501 okta/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10"
+  - "3.10-dev"
 
 install:
   - pip install -U -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - "3.10-dev"
+  - "3.10"
 
 install:
   - pip install -U -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],


### PR DESCRIPTION
The following parameter in setup.py allows package to be accessible for any python version starting from 3.6
```py
 python_requires=">=3.6",
 ```
 This PR add CI check for new python version. Additionally, update "Programming Language" section on PYPI (actual update will be made after package uploading):
 
<img width="424" alt="Screenshot 2021-10-12 at 18 53 49" src="https://user-images.githubusercontent.com/73126645/136989885-a22f2117-87a9-470c-b691-bab6d3eb5f4e.png">
