### PR TITLE
Add copyright header to all modules.

### DIFF
--- a/okta_jwt_verifier/config_validator.py
+++ b/okta_jwt_verifier/config_validator.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2021 - Present Okta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .constants import ADMIN_DOMAINS
 from .error_messages import (ERROR_MESSAGE_ORG_URL_MISSING,
                              ERROR_MESSAGE_ORG_URL_NOT_HTTPS,

--- a/okta_jwt_verifier/constants.py
+++ b/okta_jwt_verifier/constants.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2021 - Present Okta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import os
 
 

--- a/okta_jwt_verifier/error_messages.py
+++ b/okta_jwt_verifier/error_messages.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2021 - Present Okta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .constants import FINDING_OKTA_APP_CRED, FINDING_OKTA_DOMAIN
 
 ERROR_MESSAGE_ORG_URL_WRONG_TYPE = ("Your Okta URL should be type of str.")

--- a/okta_jwt_verifier/exceptions.py
+++ b/okta_jwt_verifier/exceptions.py
@@ -1,3 +1,20 @@
+"""
+Copyright 2021 - Present Okta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
 class OktaJWTBaseException(Exception):
     pass
 

--- a/okta_jwt_verifier/jwt_utils.py
+++ b/okta_jwt_verifier/jwt_utils.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2021 - Present Okta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import json
 
 from jose import jwt, jws

--- a/okta_jwt_verifier/jwt_verifier.py
+++ b/okta_jwt_verifier/jwt_verifier.py
@@ -1,3 +1,19 @@
+"""
+Copyright 2021 - Present Okta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import warnings
 
 from urllib.parse import urljoin

--- a/okta_jwt_verifier/request_executor.py
+++ b/okta_jwt_verifier/request_executor.py
@@ -1,4 +1,19 @@
-"""Module contains tools to perform http requests."""
+"""
+Copyright 2021 - Present Okta, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import time
 
 from acachecontrol import AsyncCacheControl


### PR DESCRIPTION
Add copyright header to all modules under okta-jwt-verifier package:
```
Copyright 2021 - Present Okta, Inc.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
```