### PR TITLE
Clear cache if http client fails

### DIFF
--- a/okta_jwt_verifier/jwt_verifier.py
+++ b/okta_jwt_verifier/jwt_verifier.py
@@ -211,7 +211,13 @@ class BaseJWTVerifier():
         jwks_uri = self._construct_jwks_uri()
         headers = {'User-Agent': f'okta-jwt-verifier-python/{version}',
                    'Content-Type': 'application/json'}
-        jwks = await self.request_executor.get(jwks_uri, headers=headers)
+        try:
+            jwks = await self.request_executor.get(jwks_uri, headers=headers)
+        except Exception as e: # This is needed if the http client fails
+            print('String e: '+ str(e))
+            self.request_executor.cache.release_new_key(('GET', jwks_uri))
+            self._clear_requests_cache()
+
         if not self.cache_jwks:
             self._clear_requests_cache()
         return jwks


### PR DESCRIPTION
I noticed an issue with the lib, if my http client initially failed, it would never work from that point forward until the process was restarted. 

This is an issue with the "AsynceCacheControl" lib, because it is waiting for a failed request to finish and that will never happen, however this lib could easily prevent this from happening with this PR.

To reproduce what I was seeing, in a docker container I removed the default gateway (disconnected from the internet) and attempted to verify a jwt. It fails, as it should because it cannot connect to the host. However, each subsequent failure is a "Timeout" failure, which originates here (https://github.com/MasterSergius/acachecontrol/blob/master/src/acachecontrol/cache.py#L131). 

This is because cache contains this request, it doesn't even attempt the http call again because its waiting for the failed one to finish. 

So even after the internet is reestablished it will not move passed the timeout issue until the process is restarted.

Hope this helps, and thanks for the lib!

Thanks!

