### PR TITLE
Obvious Fix - Update retry to retry2 due to vulnerability in py (dep of retry)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 *.pyc
 .pytest_cache
+.venv
 
 # Packaging generated files
 *.egg-info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
 python-jose>=3.2.0
 acachecontrol>=0.2.1
-retry
+retry2

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
         "acachecontrol",
         "aiohttp",
         "python-jose",
-        "retry"
+        "retry2"
     ]
 )


### PR DESCRIPTION
More info see - CVE-2022-42969
retry2, which is a fork of retry, doesn't have this dependency.