### PR TITLE
Updated code to verify client_id against cid instead of aud.

### DIFF
--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -117,30 +117,30 @@ def test_verify_signature(mocker):
 
 def test_verify_client_id():
     """Check if method verify_client_id works correctly."""
-    # verify when aud is a string
+    # verify when cid is a string
     client_id = 'test_client_id'
-    aud = client_id
+    cid = client_id
     jwt_verifier = BaseJWTVerifier('https://test_issuer.com', client_id)
-    jwt_verifier.verify_client_id(aud)
+    jwt_verifier.verify_client_id(cid)
 
-    # verify when aud is an array
-    aud = ['test_audience', client_id]
-    jwt_verifier.verify_client_id(aud)
+    # verify when cid is an array
+    cid = ['test_cid', client_id]
+    jwt_verifier.verify_client_id(cid)
 
-    # verify exception is raised when aud is a string
+    # verify exception is raised when cid is a string
     with pytest.raises(JWTValidationException):
-        aud = 'bad_aud'
-        jwt_verifier.verify_client_id(aud)
+        cid = 'bad_cid'
+        jwt_verifier.verify_client_id(cid)
 
-    # verify exception is raised when aud is an array
+    # verify exception is raised when cid is an array
     with pytest.raises(JWTValidationException):
-        aud = ['bad_aud']
-        jwt_verifier.verify_client_id(aud)
+        cid = ['bad_cid']
+        jwt_verifier.verify_client_id(cid)
 
-    # verify exception is raised when aud is not a string or array
+    # verify exception is raised when cid is not a string or array
     with pytest.raises(JWTValidationException):
-        aud = {'aud': 'bad_aud'}
-        jwt_verifier.verify_client_id(aud)
+        cid = {'cid': 'bad_cid'}
+        jwt_verifier.verify_client_id(cid)
 
 
 def test_verify_claims():


### PR DESCRIPTION
### Changes Made
This pull request addresses an issue in the codebase where the `client_id` was being verified against the `aud` claim, which was incorrect. The correct verification should be against the `cid` claim. This PR updates the code to verify the `client_id` against the `cid` claim and ensures the variable names in the code and tests reflect this correction.

### Details
- In the `AccessTokenVerifier` class, the `verify_client_id` method has been updated to verify the `client_id` against the `cid` claim instead of the `aud` claim.
- The corresponding tests have been updated to use the correct variable names.

### Reasons for the Change
The previous code was performing an incorrect verification of the `client_id` against the `aud` claim, which could lead to validation errors. This update ensures that the `client_id` is correctly verified against the `cid` claim, aligning with the intended functionality.

### Checklist
- [x] Code has been updated to verify `client_id` against the `cid` claim.
- [x] Tests have been modified to use the updated variable names.
- [x] Code and tests have been reviewed for correctness.
- [x] No new linting or style violations introduced.
- [x] Existing test suite passes with the changes.

### Related Issues
None.

### Additional Notes
No additional notes.