### PR TITLE
OKTA-682238: update setuptools dependency to v65.5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ retry2
 aiohttp>=3.9.2
 certifi>=2023.7.22
 urllib3>=1.26.18
+setuptools>=65.5.1


### PR DESCRIPTION
Add explicit requirement for setuptools v65.5.1 to address vulnerability in previous version.