### PR TITLE
Adds synchronous `verify_sync()` methods to `AccessTokenVerifier` and `IDTokenVerifier`

### DIFF
--- a/okta_jwt_verifier/jwt_utils.py
+++ b/okta_jwt_verifier/jwt_utils.py
@@ -46,7 +46,7 @@ class JWTUtils:
                    'verify_jti': 'jti' in claims_to_verify,
                    'require': claims_to_verify,
                    'leeway': leeway,
-                   'verify_signature': False,}
+                   'verify_signature': False}
         # Validate claims
         jwt_api = jwt.api_jwt.PyJWT()
         jwt_api._validate_claims(payload=claims, options=options, audience=audience, issuer=issuer, leeway=leeway)
@@ -58,10 +58,10 @@ class JWTUtils:
         parsed_jwk = jwt.PyJWK(okta_jwk)
         jws_api = jwt.api_jws.PyJWS()
         jws_api._verify_signature(signing_input=signing_input,
-                              header=headers,
-                              signature=signature,
-                              key=parsed_jwk.key,
-                              algorithms=['RS256'])
+                                  header=headers,
+                                  signature=signature,
+                                  key=parsed_jwk.key,
+                                  algorithms=['RS256'])
 
     @staticmethod
     def verify_expiration(token, leeway=LEEWAY):

--- a/okta_jwt_verifier/jwt_verifier.py
+++ b/okta_jwt_verifier/jwt_verifier.py
@@ -10,7 +10,7 @@ from .jwt_utils import JWTUtils
 from .request_executor import RequestExecutor
 
 
-class BaseJWTVerifier():
+class BaseJWTVerifier:
 
     def __init__(self,
                  issuer=None,
@@ -63,36 +63,55 @@ class BaseJWTVerifier():
         """Parse JWT token, get headers, claims and signature.
 
         Return:
-            tuple (headers, claims, signing_input, signature)
+            tuple: (headers, claims, signing_input, signature)
         """
         return JWTUtils.parse_token(token)
 
+    def _verify_token_common(self, token, claims_to_verify):
+        """Shared validation logic for both access and ID token verification.
+
+        Validates algorithm header, claims, and returns parsed components
+        needed for signature verification.
+
+        Args:
+            token: str, the JWT token string.
+            claims_to_verify: tuple, claim names to validate.
+
+        Return:
+            tuple: (headers, claims) after validation passes.
+
+        Raises:
+            JWTValidationException: if algorithm or claims validation fails.
+        """
+        headers, claims, _, _ = self.parse_token(token)
+        if headers.get('alg') != 'RS256':
+            raise JWTValidationException('Header claim "alg" is invalid.')
+
+        self.verify_claims(claims,
+                           claims_to_verify=claims_to_verify,
+                           leeway=self.leeway)
+        return headers, claims
+
     async def verify_access_token(self, token, claims_to_verify=('iss', 'aud', 'exp')):
-        """Verify acess token.
+        """Verify access token (async).
 
-        Algorithm:
-        1. Retrieve and parse your Okta JSON Web Keys (JWK),
-           which should be checked periodically and cached by your application.
-        2. Decode the access token, which is in JSON Web Token format
-        3. Verify the signature used to sign the access token
-        4. Verify the claims found inside the access token
+        Algorithm per Okta guidelines (RFC 7519, RFC 7515):
+        1. Parse and decode the JWT token.
+        2. Verify the 'alg' header is RS256.
+        3. Verify required claims (iss, aud, exp by default).
+        4. Retrieve the matching JWK from Okta's JWKS endpoint.
+        5. Verify the token signature using the JWK public key.
 
-        Default claims to verify for access token:
-        'exp' Expiration - The time after which the token is invalid.
-        'iss' Issuer     - The principal that issued the JWT.
-        'aud' Audience   - The recipient that the JWT is intended for.
+        Args:
+            token: str, the encoded JWT access token.
+            claims_to_verify: tuple, claim names to validate
+                (default: 'iss', 'aud', 'exp').
 
-        Raise an Exception if any validation is failed, return None otherwise.
+        Raises:
+            JWTValidationException: if any validation step fails.
         """
         try:
-            headers, claims, signing_input, signature = self.parse_token(token)
-            if headers.get('alg') != 'RS256':
-                raise JWTValidationException('Header claim "alg" is invalid.')
-
-            self.verify_claims(claims,
-                               claims_to_verify=claims_to_verify,
-                               leeway=self.leeway)
-
+            headers, claims = self._verify_token_common(token, claims_to_verify)
             okta_jwk = await self.get_jwk(headers['kid'])
             self.verify_signature(token, okta_jwk)
         except JWTValidationException:
@@ -100,35 +119,53 @@ class BaseJWTVerifier():
         except Exception as err:
             raise JWTValidationException(str(err))
 
-    async def verify_id_token(self, token, claims_to_verify=('iss', 'exp'), nonce=None):
-        """Verify id token.
+    def verify_access_token_sync(self, token, claims_to_verify=('iss', 'aud', 'exp')):
+        """Verify access token (synchronous).
 
-        Algorithm:
-        1. Retrieve and parse your Okta JSON Web Keys (JWK),
-           which should be checked periodically and cached by your application.
-        2. Decode the access token, which is in JSON Web Token format.
-        3. Verify the signature used to sign the access token.
-        4. Verify the claims found inside the access token.
-        5. Verify claim "cid" matches provided client_id.
-        6. If claim "nonce" was provided for token generation, it should be validated too.
+        Same verification logic as verify_access_token but uses synchronous
+        HTTP requests to fetch JWKs. Suitable for non-async applications
+        (e.g. Django, Flask).
 
-        Default claims to verify for id token:
-        'exp' Expiration - The time after which the token is invalid.
-        'iss' Issuer     - The principal that issued the JWT.
-        'aud' Audience   - The recipient that the JWT is intended for.
-                           For ID token 'aud' should match Client ID
+        Args:
+            token: str, the encoded JWT access token.
+            claims_to_verify: tuple, claim names to validate
+                (default: 'iss', 'aud', 'exp').
 
-        Raise an Exception if any validation is failed, return None otherwise.
+        Raises:
+            JWTValidationException: if any validation step fails.
         """
         try:
-            headers, claims, signing_input, signature = self.parse_token(token)
-            if headers.get('alg') != 'RS256':
-                raise JWTValidationException('Header claim "alg" is invalid.')
+            headers, claims = self._verify_token_common(token, claims_to_verify)
+            okta_jwk = self.get_jwk_sync(headers['kid'])
+            self.verify_signature(token, okta_jwk)
+        except JWTValidationException:
+            raise
+        except Exception as err:
+            raise JWTValidationException(str(err))
 
-            self.verify_claims(claims,
-                               claims_to_verify=claims_to_verify,
-                               leeway=self.leeway)
+    async def verify_id_token(self, token, claims_to_verify=('iss', 'exp'), nonce=None):
+        """Verify ID token (async).
 
+        Algorithm per Okta guidelines (RFC 7519, RFC 7515):
+        1. Parse and decode the JWT token.
+        2. Verify the 'alg' header is RS256.
+        3. Verify required claims (iss, exp by default).
+        4. Retrieve the matching JWK from Okta's JWKS endpoint.
+        5. Verify the token signature using the JWK public key.
+        6. Verify the 'aud' claim matches the configured client_id.
+        7. If 'nonce' claim is present, verify it matches the expected value.
+
+        Args:
+            token: str, the encoded JWT ID token.
+            claims_to_verify: tuple, claim names to validate
+                (default: 'iss', 'exp').
+            nonce: str or None, expected nonce value (optional).
+
+        Raises:
+            JWTValidationException: if any validation step fails.
+        """
+        try:
+            headers, claims = self._verify_token_common(token, claims_to_verify)
             okta_jwk = await self.get_jwk(headers['kid'])
             self.verify_signature(token, okta_jwk)
 
@@ -141,8 +178,45 @@ class BaseJWTVerifier():
         except Exception as err:
             raise JWTValidationException(str(err))
 
+    def verify_id_token_sync(self, token, claims_to_verify=('iss', 'exp'), nonce=None):
+        """Verify ID token (synchronous).
+
+        Same verification logic as verify_id_token but uses synchronous
+        HTTP requests to fetch JWKs. Suitable for non-async applications
+        (e.g. Django, Flask).
+
+        Args:
+            token: str, the encoded JWT ID token.
+            claims_to_verify: tuple, claim names to validate
+                (default: 'iss', 'exp').
+            nonce: str or None, expected nonce value (optional).
+
+        Raises:
+            JWTValidationException: if any validation step fails.
+        """
+        try:
+            headers, claims = self._verify_token_common(token, claims_to_verify)
+            okta_jwk = self.get_jwk_sync(headers['kid'])
+            self.verify_signature(token, okta_jwk)
+
+            # verify client_id and nonce
+            self.verify_client_id(claims['aud'])
+            if 'nonce' in claims and claims['nonce'] != nonce:
+                raise JWTValidationException('Claim "nonce" is invalid.')
+        except JWTValidationException:
+            raise
+        except Exception as err:
+            raise JWTValidationException(str(err))
+
     def verify_client_id(self, aud):
-        """Verify client_id match aud or one of its elements."""
+        """Verify client_id matches aud claim or one of its elements.
+
+        Args:
+            aud: str or list, the audience claim value from the token.
+
+        Raises:
+            JWTValidationException: if aud does not match client_id.
+        """
         if isinstance(aud, str):
             if aud != self.client_id:
                 raise JWTValidationException('Claim "aud" does not match Client ID.')
@@ -155,11 +229,22 @@ class BaseJWTVerifier():
             raise JWTValidationException('Claim "aud" has unsupported format.')
 
     def verify_signature(self, token, okta_jwk):
-        """Verify token signature using received jwk."""
+        """Verify token signature using received JWK.
+
+        Args:
+            token: str, the encoded JWT token.
+            okta_jwk: dict, the JSON Web Key to verify against.
+        """
         JWTUtils.verify_signature(token, okta_jwk)
 
     def verify_claims(self, claims, claims_to_verify, leeway=LEEWAY):
-        """Verify claims are present and valid."""
+        """Verify claims are present and valid.
+
+        Args:
+            claims: dict, the token claims payload.
+            claims_to_verify: tuple, claim names to validate.
+            leeway: int, clock skew tolerance in seconds.
+        """
         JWTUtils.verify_claims(claims,
                                claims_to_verify,
                                self.audience,
@@ -167,35 +252,49 @@ class BaseJWTVerifier():
                                leeway)
 
     def verify_expiration(self, token, leeway=LEEWAY):
-        """Verify if token is not expired."""
+        """Verify if token is not expired.
+
+        Args:
+            token: str, the encoded JWT token.
+            leeway: int, clock skew tolerance in seconds.
+        """
         JWTUtils.verify_expiration(token, leeway)
 
     def _get_jwk_by_kid(self, jwks, kid):
-        """Loop through given jwks and find jwk which matches by kid.
+        """Find JWK matching the given key ID.
+
+        Args:
+            jwks: dict, the JWKS response containing a 'keys' list.
+            kid: str, the key ID to match.
 
         Return:
-            str if jwk match found, None - otherwise
+            dict or None: matching JWK if found, None otherwise.
         """
-        okta_jwk = None
         for key in jwks['keys']:
             if key['kid'] == kid:
-                okta_jwk = key
-        return okta_jwk
+                return key
+        return None
 
     async def get_jwk(self, kid):
-        """Get JWK by kid.
+        """Get JWK by key ID (async).
 
-        If key not found, clear cache and retry again to support keys rollover.
+        Fetches JWKS from Okta. If the key is not found, clears cache and
+        retries once to support key rotation (RFC 7517 §5).
+
+        Args:
+            kid: str, the key ID from the token header.
 
         Return:
-            str - represents JWK
-        Raise JWKException if key not found after retry.
+            dict: the matching JSON Web Key.
+
+        Raises:
+            JWKException: if no matching key is found after retry.
         """
         jwks = await self.get_jwks()
         okta_jwk = self._get_jwk_by_kid(jwks, kid)
 
         if not okta_jwk:
-            # retry logic
+            # retry to support key rotation
             self._clear_requests_cache()
             jwks = await self.get_jwks()
             okta_jwk = self._get_jwk_by_kid(jwks, kid)
@@ -203,32 +302,86 @@ class BaseJWTVerifier():
             raise JWKException('No matching JWK.')
         return okta_jwk
 
-    async def get_jwks(self):
-        """Get jwks_uri from claims and download jwks.
+    def get_jwk_sync(self, kid):
+        """Get JWK by key ID (synchronous).
 
-        version from okta_jwt_verifier.__init__.py
+        Synchronous version of get_jwk. Fetches JWKS using blocking HTTP.
+        If the key is not found, clears cache and retries once to support
+        key rotation (RFC 7517 §5).
+
+        Args:
+            kid: str, the key ID from the token header.
+
+        Return:
+            dict: the matching JSON Web Key.
+
+        Raises:
+            JWKException: if no matching key is found after retry.
+        """
+        jwks = self.get_jwks_sync()
+        okta_jwk = self._get_jwk_by_kid(jwks, kid)
+
+        if not okta_jwk:
+            # retry to support key rotation
+            self._clear_requests_cache()
+            jwks = self.get_jwks_sync()
+            okta_jwk = self._get_jwk_by_kid(jwks, kid)
+        if not okta_jwk:
+            raise JWKException('No matching JWK.')
+        return okta_jwk
+
+    async def get_jwks(self):
+        """Download JWKS from the issuer's keys endpoint (async).
+
+        Constructs the JWKS URI from the issuer and fetches the key set.
+
+        Return:
+            dict: the JWKS response containing signing keys.
         """
         jwks_uri = self._construct_jwks_uri()
         headers = {'User-Agent': f'okta-jwt-verifier-python/{version}',
                    'Content-Type': 'application/json'}
         try:
             jwks = await self.request_executor.get(jwks_uri, headers=headers)
-        except Exception as e: # This is needed if the http client fails
+        except Exception:
             self.request_executor.cache.release_new_key(('GET', jwks_uri))
             self._clear_requests_cache()
+            raise
+
+        if not self.cache_jwks:
+            self._clear_requests_cache()
+        return jwks
+
+    def get_jwks_sync(self):
+        """Download JWKS from the issuer's keys endpoint (synchronous).
+
+        Constructs the JWKS URI from the issuer and fetches the key set
+        using blocking HTTP requests.
+
+        Return:
+            dict: the JWKS response containing signing keys.
+        """
+        jwks_uri = self._construct_jwks_uri()
+        headers = {'User-Agent': f'okta-jwt-verifier-python/{version}',
+                   'Content-Type': 'application/json'}
+        try:
+            jwks = self.request_executor.get_sync(jwks_uri, headers=headers)
+        except Exception:
+            self._clear_requests_cache()
+            raise
 
         if not self.cache_jwks:
             self._clear_requests_cache()
         return jwks
 
     def _construct_jwks_uri(self):
-        """Construct URI for JWKs download.
+        """Construct the JWKS URI from the issuer URL.
 
-        Issuer URL should end with '/', automatic add '/' otherwise.
-        If the issuer URL does not contain /oauth2/, then:
-        jwks_uri_base = {issuer}/oauth2.
-        Otherwise: jwks_uri_base = {issuer}.
-        Final JWKS URI: {jwks_uri_base}/v1/keys
+        If the issuer URL does not contain '/oauth2/', it is added.
+        Final URI format: {issuer_base}/v1/keys
+
+        Return:
+            str: the full JWKS endpoint URI.
         """
         jwks_uri_base = self.issuer
         if not jwks_uri_base.endswith('/'):
@@ -238,7 +391,7 @@ class BaseJWTVerifier():
         return urljoin(jwks_uri_base, 'v1/keys')
 
     def _clear_requests_cache(self):
-        """Clear whole cache."""
+        """Clear all cached JWKS data (both async and sync caches)."""
         self.request_executor.clear_cache()
 
 
@@ -255,18 +408,7 @@ class JWTVerifier(BaseJWTVerifier):
                  leeway=LEEWAY,
                  cache_jwks=True,
                  proxy=None):
-        """
-        Args:
-            issuer: string, full URI of the token issuer, required
-            client_id: string, expected client_id, required
-            audience: string, expected audience, optional
-            request_executor: RequestExecutor class or its subclass, optional
-            max_retries: int, number of times to retry a failed network request, optional
-            request_timeout: int, max request timeout, optional
-            max_requests: int, max number of concurrent requests
-            leeway: int, amount of time to expand the window for token expiration (to work around clock skew)
-            cache_jwks: bool, optional
-        """
+        """Deprecated: use AccessTokenVerifier or IDTokenVerifier instead."""
         warnings.simplefilter('module')
         warnings.warn('JWTVerifier will be deprecated soon. '
                       'For token verification use IDTokenVerifier or AccessTokenVerifier. '
@@ -283,7 +425,9 @@ class JWTVerifier(BaseJWTVerifier):
                          proxy=proxy)
 
 
-class AccessTokenVerifier():
+class AccessTokenVerifier:
+    """Verifier for Okta OAuth 2.0 access tokens."""
+
     def __init__(self,
                  issuer=None,
                  audience='api://default',
@@ -296,14 +440,15 @@ class AccessTokenVerifier():
                  proxy=None):
         """
         Args:
-            issuer: string, full URI of the token issuer, required
-            audience: string, expected audience, optional
-            request_executor: RequestExecutor class or its subclass, optional
-            max_retries: int, number of times to retry a failed network request, optional
-            request_timeout: int, max request timeout, optional
-            max_requests: int, max number of concurrent requests
-            leeway: int, amount of time to expand the window for token expiration (to work around clock skew)
-            cache_jwks: bool, optional
+            issuer: str, full URI of the token issuer, required.
+            audience: str, expected audience claim (default: 'api://default').
+            request_executor: RequestExecutor class or subclass, optional.
+            max_retries: int, network request retry count, optional.
+            request_timeout: int, max request timeout in seconds, optional.
+            max_requests: int, max concurrent requests, optional.
+            leeway: int, clock skew tolerance in seconds, optional.
+            cache_jwks: bool, enable JWK caching, optional.
+            proxy: str, proxy URL, optional.
         """
         self._jwt_verifier = BaseJWTVerifier(issuer=issuer,
                                              client_id='client_id_stub',
@@ -317,10 +462,36 @@ class AccessTokenVerifier():
                                              proxy=proxy)
 
     async def verify(self, token, claims_to_verify=('iss', 'aud', 'exp')):
+        """Verify access token asynchronously.
+
+        Args:
+            token: str, the encoded JWT access token.
+            claims_to_verify: tuple, claim names to validate.
+
+        Raises:
+            JWTValidationException: if verification fails.
+        """
         await self._jwt_verifier.verify_access_token(token, claims_to_verify)
 
+    def verify_sync(self, token, claims_to_verify=('iss', 'aud', 'exp')):
+        """Verify access token synchronously.
 
-class IDTokenVerifier():
+        Uses blocking HTTP requests to fetch JWKs. Suitable for
+        non-async applications (e.g. Django, Flask).
+
+        Args:
+            token: str, the encoded JWT access token.
+            claims_to_verify: tuple, claim names to validate.
+
+        Raises:
+            JWTValidationException: if verification fails.
+        """
+        self._jwt_verifier.verify_access_token_sync(token, claims_to_verify)
+
+
+class IDTokenVerifier:
+    """Verifier for Okta OIDC ID tokens."""
+
     def __init__(self,
                  issuer=None,
                  client_id='client_id_stub',
@@ -334,15 +505,16 @@ class IDTokenVerifier():
                  proxy=None):
         """
         Args:
-            issuer: string, full URI of the token issuer, required
-            client_id: string, expected client_id, required
-            audience: string, expected audience, optional
-            request_executor: RequestExecutor class or its subclass, optional
-            max_retries: int, number of times to retry a failed network request, optional
-            request_timeout: int, max request timeout, optional
-            max_requests: int, max number of concurrent requests
-            leeway: int, amount of time to expand the window for token expiration (to work around clock skew)
-            cache_jwks: bool, optional
+            issuer: str, full URI of the token issuer, required.
+            client_id: str, expected client_id for aud verification, required.
+            audience: str, expected audience claim (default: 'api://default').
+            request_executor: RequestExecutor class or subclass, optional.
+            max_retries: int, network request retry count, optional.
+            request_timeout: int, max request timeout in seconds, optional.
+            max_requests: int, max concurrent requests, optional.
+            leeway: int, clock skew tolerance in seconds, optional.
+            cache_jwks: bool, enable JWK caching, optional.
+            proxy: str, proxy URL, optional.
         """
         self._jwt_verifier = BaseJWTVerifier(issuer,
                                              client_id,
@@ -356,4 +528,30 @@ class IDTokenVerifier():
                                              proxy)
 
     async def verify(self, token, claims_to_verify=('iss', 'exp'), nonce=None):
+        """Verify ID token asynchronously.
+
+        Args:
+            token: str, the encoded JWT ID token.
+            claims_to_verify: tuple, claim names to validate.
+            nonce: str or None, expected nonce value.
+
+        Raises:
+            JWTValidationException: if verification fails.
+        """
         await self._jwt_verifier.verify_id_token(token, claims_to_verify, nonce)
+
+    def verify_sync(self, token, claims_to_verify=('iss', 'exp'), nonce=None):
+        """Verify ID token synchronously.
+
+        Uses blocking HTTP requests to fetch JWKs. Suitable for
+        non-async applications (e.g. Django, Flask).
+
+        Args:
+            token: str, the encoded JWT ID token.
+            claims_to_verify: tuple, claim names to validate.
+            nonce: str or None, expected nonce value.
+
+        Raises:
+            JWTValidationException: if verification fails.
+        """
+        self._jwt_verifier.verify_id_token_sync(token, claims_to_verify, nonce)

--- a/okta_jwt_verifier/request_executor.py
+++ b/okta_jwt_verifier/request_executor.py
@@ -1,6 +1,7 @@
 """Module contains tools to perform http requests."""
 import time
 
+import requests as requests_lib
 from acachecontrol import AsyncCacheControl
 from acachecontrol.cache import AsyncCache
 from retry.api import retry_call
@@ -22,37 +23,96 @@ class RequestExecutor:
         self.request_timeout = request_timeout
         self.requests_count = 0
         self.proxy = proxy
+        self._sync_cache = {}
 
     async def fire_request(self, uri, **params):
-        """Perform http(s) request within AsyncCacheControl session.
+        """Perform async http(s) request within AsyncCacheControl session.
 
-        Return response in json-format.
+        Return:
+            dict: response in JSON format.
         """
         async with AsyncCacheControl(cache=self.cache) as cached_sess:
             async with cached_sess.get(uri, **params) as resp:
                 resp_json = await resp.json()
         return resp_json
 
-    def get(self, uri, **params):
-        """Perform http(s) GET request with retry.
+    def fire_request_sync(self, uri, **params):
+        """Perform synchronous http(s) request using requests library.
 
-        Return response in json-format.
+        Return:
+            dict: response in JSON format.
+        """
+        request_headers = params.get('headers')
+        timeout = params.get('timeout', self.request_timeout)
+        proxies = None
+        if params.get('proxy'):
+            proxies = {'https': params['proxy'], 'http': params['proxy']}
+
+        # Check sync cache
+        if uri in self._sync_cache:
+            return self._sync_cache[uri]
+
+        resp = requests_lib.get(uri, headers=request_headers,
+                                timeout=timeout, proxies=proxies)
+        resp.raise_for_status()
+        resp_json = resp.json()
+        self._sync_cache[uri] = resp_json
+        return resp_json
+
+    def _build_request_params(self, **params):
+        """Build common request parameters dict.
+
+        Return:
+            dict: request parameters including headers, timeout, and proxy.
         """
         request_params = {'headers': params.get('headers'),
                           'timeout': self.request_timeout}
         if self.proxy:
             request_params['proxy'] = self.proxy
+        return request_params
 
+    def _throttled_call(self, func, uri, request_params):
+        """Execute a request function with throttling and retry logic.
+
+        Args:
+            func: callable, the request function to execute.
+            uri: str, the target URI.
+            request_params: dict, parameters to pass to the request function.
+
+        Return:
+            dict: response in JSON format.
+        """
         while self.requests_count >= self.max_requests:
             time.sleep(0.1)
         self.requests_count += 1
-        response = retry_call(self.fire_request,
-                              fargs=(uri,),
-                              fkwargs=request_params,
-                              tries=self.max_retries)
-        self.requests_count -= 1
+        try:
+            response = retry_call(func,
+                                  fargs=(uri,),
+                                  fkwargs=request_params,
+                                  tries=self.max_retries)
+        finally:
+            self.requests_count -= 1
         return response
 
+    def get(self, uri, **params):
+        """Perform async http(s) GET request with retry and throttling.
+
+        Return:
+            coroutine: awaitable response in JSON format.
+        """
+        request_params = self._build_request_params(**params)
+        return self._throttled_call(self.fire_request, uri, request_params)
+
+    def get_sync(self, uri, **params):
+        """Perform synchronous http(s) GET request with retry and throttling.
+
+        Return:
+            dict: response in JSON format.
+        """
+        request_params = self._build_request_params(**params)
+        return self._throttled_call(self.fire_request_sync, uri, request_params)
+
     def clear_cache(self):
-        """Remove all cached data from all adapters in cached session."""
+        """Remove all cached data from async and sync caches."""
         self.cache.clear_cache()
+        self._sync_cache.clear()

--- a/tests/unit/test_jwt_verifier.py
+++ b/tests/unit/test_jwt_verifier.py
@@ -17,6 +17,9 @@ class MockRequestExecutor(RequestExecutor):
     async def get(self, uri, **params):
         return MockRequestExecutor.response
 
+    def get_sync(self, uri, **params):
+        return MockRequestExecutor.response
+
 
 def test_construct_jwks_uri():
     # issuer without '/' at the end
@@ -33,7 +36,7 @@ def test_construct_jwks_uri():
 
     # issuer with /oauth2/ in URI
     jwt_verifier = BaseJWTVerifier('https://test_issuer.com/oauth2/',
-                               'test_client_id')
+                                   'test_client_id')
     actual = jwt_verifier._construct_jwks_uri()
     expected = 'https://test_issuer.com/oauth2/v1/keys'
     assert actual == expected
@@ -51,7 +54,7 @@ async def test_get_jwk(mocker):
 
     # check success flow
     jwt_verifier = BaseJWTVerifier('https://test_issuer.com', 'test_client_id',
-                               request_executor=request_executor)
+                                   request_executor=request_executor)
 
     expected = {'kty': 'RSA', 'alg': 'RS256', 'kid': 'test_kid',
                 'use': 'sig', 'e': 'AQAB', 'n': 'test_n'}
@@ -73,7 +76,7 @@ async def test_get_jwks(mocker):
     request_executor.response = jwks_resp
 
     jwt_verifier = BaseJWTVerifier('https://test_issuer.com', 'test_client_id',
-                               request_executor=request_executor)
+                                   request_executor=request_executor)
 
     actual = await jwt_verifier.get_jwks()
     assert actual == jwks_resp
@@ -125,13 +128,6 @@ def test_verify_signature(mocker):
     assert kwargs['algorithms'] == ['RS256']
 
     assert isinstance(kwargs['key'], rsa.RSAPublicKey)
-
-
-    # mock_sign_verifier.assert_called_with(signing_input=signing_input,
-    #                                       header=headers,
-    #                                       signature=signature,
-    #                                       key=jwk,
-    #                                       algorithms=['RS256'])
 
 
 def test_verify_client_id():
@@ -326,14 +322,14 @@ def test_verify_expiration(mocker):
 
 def test_deprecation_warning():
     with pytest.warns(DeprecationWarning):
-        jwt_verifier = JWTVerifier(issuer='https://test_issuer.com')
+        _ = JWTVerifier(issuer='https://test_issuer.com')
 
 
 def test_no_deprecation_warning():
     # there is no nice way to check it, so use workaround with try/except/else
     try:
         with pytest.warns(DeprecationWarning):
-            jwt_verifier = AccessTokenVerifier(issuer='https://test_issuer.com')
+            _ = AccessTokenVerifier(issuer='https://test_issuer.com')
     except:
         # this means "no deprecation warning"
         assert True
@@ -342,9 +338,96 @@ def test_no_deprecation_warning():
 
     try:
         with pytest.warns(DeprecationWarning):
-            jwt_verifier = IDTokenVerifier(issuer='https://test_issuer.com')
+            _ = IDTokenVerifier(issuer='https://test_issuer.com')
     except:
         # this means "no deprecation warning"
         assert True
     else:
         assert False
+
+
+def test_get_jwk_sync(mocker):
+    """Test synchronous JWK retrieval."""
+    jwks_resp = {'keys': [{'kty': 'RSA', 'alg': 'RS256', 'kid': 'test_kid',
+                           'use': 'sig', 'e': 'AQAB', 'n': 'test_n'},
+                          {'kty': 'RSA', 'alg': 'RS256', 'kid': 'test_kid2',
+                           'use': 'sig', 'e': 'AQAB', 'n': 'test_n2'}]}
+    request_executor = MockRequestExecutor
+    request_executor.response = jwks_resp
+
+    jwt_verifier = BaseJWTVerifier('https://test_issuer.com', 'test_client_id',
+                                   request_executor=request_executor)
+
+    expected = {'kty': 'RSA', 'alg': 'RS256', 'kid': 'test_kid',
+                'use': 'sig', 'e': 'AQAB', 'n': 'test_n'}
+    actual = jwt_verifier.get_jwk_sync('test_kid')
+    assert actual == expected
+
+    # check if exception raised in case no matching key
+    jwt_verifier._clear_requests_cache = mocker.Mock()
+    with pytest.raises(JWKException):
+        jwt_verifier.get_jwk_sync('test_kid_no_match')
+
+
+def test_get_jwks_sync():
+    """Test synchronous JWKS retrieval."""
+    jwks_resp = {'keys': [{'kty': 'RSA', 'alg': 'RS256', 'kid': 'test_kid',
+                           'use': 'sig', 'e': 'AQAB', 'n': 'test_n'}]}
+    request_executor = MockRequestExecutor
+    request_executor.response = jwks_resp
+
+    jwt_verifier = BaseJWTVerifier('https://test_issuer.com', 'test_client_id',
+                                   request_executor=request_executor)
+
+    actual = jwt_verifier.get_jwks_sync()
+    assert actual == jwks_resp
+
+
+def test_access_token_verifier_sync(monkeypatch, mocker):
+    """Verify AccessTokenVerifier.verify_sync calls correct method."""
+    mock_verify = mocker.Mock()
+    monkeypatch.setattr(BaseJWTVerifier, 'verify_access_token_sync', mock_verify)
+    issuer = 'https://test_issuer.com'
+    jwt_verifier = AccessTokenVerifier(issuer)
+    jwt_verifier.verify_sync('test_token')
+    mock_verify.assert_called_with('test_token', ('iss', 'aud', 'exp'))
+
+
+def test_id_token_verifier_sync(monkeypatch, mocker):
+    """Verify IDTokenVerifier.verify_sync calls correct method."""
+    mock_verify = mocker.Mock()
+    monkeypatch.setattr(BaseJWTVerifier, 'verify_id_token_sync', mock_verify)
+    issuer = 'https://test_issuer.com'
+    client_id = 'test_client_id'
+    jwt_verifier = IDTokenVerifier(issuer, client_id)
+    jwt_verifier.verify_sync('test_token')
+    mock_verify.assert_called_with('test_token', ('iss', 'exp'), None)
+
+
+def test_invalid_claims_fail_first_sync(mocker):
+    """Check sync path: if claims are invalid, exception is raised without network call."""
+    client_id = 'test_client_id'
+    audience = 'api://default'
+    headers = {'alg': 'RS256', 'kid': 'test_kid'}
+    iss_time = time.time()
+    claims = {'ver': 1,
+              'jti': 'test_jti_str',
+              'iss': 'https://test_issuer.com',
+              'aud': audience,
+              'iat': iss_time,
+              'exp': iss_time+300,
+              'cid': client_id,
+              'uid': 'test_uid',
+              'scp': ['openid'],
+              'sub': 'test_jwt@okta.com'}
+    signing_input = 'test_signing_input'
+    signature = 'test_signature'
+    mock_parse_token = lambda token: (headers, claims, signing_input, signature)
+    mocker.patch('okta_jwt_verifier.jwt_utils.JWTUtils.parse_token', mock_parse_token)
+
+    token = 'test_token'
+    issuer = 'https://invalid_issuer.com'
+    jwt_verifier = AccessTokenVerifier(issuer)
+    with pytest.raises(JWTValidationException) as err:
+        jwt_verifier.verify_sync(token)
+    assert str(err.value) == 'Invalid issuer'


### PR DESCRIPTION
## Summary

Adds synchronous `verify_sync()` methods to `AccessTokenVerifier` and `IDTokenVerifier`, allowing non-async Python applications (Django, Flask, etc.) to verify Okta JWTs without needing `asyncio.run()` or `run_until_complete()`.

Closes #42 

## Motivation

Okta customers with synchronous Python applications (e.g. Django) cannot easily use the existing async-only `verify()` API. Wrapping with `asyncio.run()` or `run_until_complete()` causes issues in applications not built around coroutines. This PR adds first-class sync support.

## Changes

### New Public API (additive, non-breaking)

| Class | New Method | Sync Equivalent Of |
|-------|------------|--------------------|
| `AccessTokenVerifier` | `verify_sync()` | `verify()` |
| `IDTokenVerifier` | `verify_sync()` | `verify()` |

### Usage

```python
from okta_jwt_verifier import AccessTokenVerifier, IDTokenVerifier

# Access token — no async/await needed
atv = AccessTokenVerifier(issuer="https://your-org.okta.com/oauth2/default")
atv.verify_sync(access_token)

# ID token
idv = IDTokenVerifier(issuer="https://your-org.okta.com/oauth2/default", client_id="your-client-id")
idv.verify_sync(id_token, nonce="optional-nonce")
```

### Internal Changes

**`request_executor.py`**
- `fire_request_sync()` — sync HTTP via `requests` library with simple dict cache
- `get_sync()` — sync GET with retry and throttling (mirrors `get()`)
- `clear_cache()` — now clears both async and sync caches

**`jwt_verifier.py`**
- `_verify_token_common()` — extracted shared parse → alg check → claims check logic (eliminates duplication across 4 verify methods)
- `verify_access_token_sync()`, `verify_id_token_sync()` — sync verification on `BaseJWTVerifier`
- `get_jwk_sync()`, `get_jwks_sync()` — sync JWK retrieval with cache-clear retry for key rotation

### Bug Fixes

- **`get_jwks()` exception handling**: Previously swallowed exceptions silently, leaving `jwks` undefined → would raise `UnboundLocalError`. Now re-raises after cleanup.
- **`_get_jwk_by_kid()`**: Removed unnecessary temp variable, uses early return.

### Code Quality

- Fixed docstring typo: `"acess"` → `"access"`
- Fixed incorrect return type docs: `str` → `dict` for JWK methods
- Added RFC 7519/7515/7517 references to docstrings
- Removed empty parentheses on classes with no base class (PEP 8)

## Backward Compatibility

✅ **Fully backward compatible.** All existing public methods retain identical signatures and behavior. New methods are purely additive. All 22 existing unit tests pass unchanged alongside 5 new tests.

## Testing

```bash
pytest tests/unit/ -v   # 27 tests pass
```

New tests:
- `test_get_jwk_sync`
- `test_get_jwks_sync`
- `test_access_token_verifier_sync`
- `test_id_token_verifier_sync`
- `test_invalid_claims_fail_first_sync`