### PR TITLE
fix: declare requests runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.8"
 PyJWT = "^2.8.0"
 acachecontrol = "^0.3.6"
 retry2 = "^0.9.5"
+requests = "^2.32.0"
 
 [tool.poetry.group.dev.dependencies]
 cryptography = ">=43.0.0"


### PR DESCRIPTION
Fixes #95.

okta_jwt_verifier/request_executor.py imports equests directly, so the package should declare it as a runtime dependency.

This adds equests to [tool.poetry.dependencies] so clean installs include the module needed during import/runtime.